### PR TITLE
Fix SharedStringAsset instantiation / log spam

### DIFF
--- a/BugFixes/BugFixes.csproj
+++ b/BugFixes/BugFixes.csproj
@@ -60,6 +60,10 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\..\..\..\..\..\Program Files\Epic Games\PathfinderWOTR\Wrath_Data\Managed\Newtonsoft.Json.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="UnityEngine">
       <HintPath>..\..\..\..\..\..\Program Files\Epic Games\PathfinderWOTR\Wrath_Data\Managed\UnityEngine.dll</HintPath>
       <Private>False</Private>

--- a/BugFixes/Main.cs
+++ b/BugFixes/Main.cs
@@ -23,29 +23,20 @@ using Kingmaker.Utility;
 using Kingmaker.Blueprints.JsonSystem;
 using Kingmaker.Blueprints;
 using Kingmaker.UnitLogic.Abilities.Blueprints;
-using Kingmaker.Visual.Animation.Kingmaker;
 using Kingmaker.Visual.Animation.Kingmaker.Actions;
 using Kingmaker.UnitLogic.Buffs.Blueprints;
 using Kingmaker.Designers.Mechanics.Buffs;
 using Kingmaker.Items.Slots;
-using System.Runtime.CompilerServices;
-using Kingmaker.EntitySystem.Persistence;
 using Kingmaker.UnitLogic.Mechanics.Actions;
 using Kingmaker.ElementsSystem;
 using Kingmaker.UI.GenericSlot;
 using Kingmaker.Blueprints.Items.Ecnchantments;
 using Kingmaker.Blueprints.Facts;
 using Kingmaker.Controllers;
-using Kingmaker.RuleSystem.Rules.Abilities;
-using Kingmaker.UnitLogic.Abilities.Components;
-using Kingmaker.Settings.Difficulty;
-using Kingmaker.Settings;
-using Kingmaker.Blueprints.Items.Equipment;
-using Kingmaker.Craft;
 
 namespace BugFixes
 {
-    static class Main
+  static class Main
     {
         public static UnityModManager.ModEntry modEntry;
 

--- a/BugFixes/Properties/AssemblyInfo.cs
+++ b/BugFixes/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/BugFixes/info.json
+++ b/BugFixes/info.json
@@ -6,5 +6,6 @@
   "Version": "1.0.4",
   "Requirements": [],
   "AssemblyName": "BugFixes.dll",
-  "EntryMethod": "BugFixes.Main.Load"
+  "EntryMethod": "BugFixes.Main.Load",
+  "LoadAfter": ["MewsiferConsole.Mod"]
 }


### PR DESCRIPTION
`SharedStringAsset` is a `ScriptableObject` which must be instantiated using `ScriptableObject.CreateInstance()`. Owlcat's implementation uses `new()` leading to 10k+ log lines when loading mods using WrathModificationTemplate, e.g. [Homebrew Archetypes](https://www.nexusmods.com/pathfinderwrathoftherighteous/mods/279?tab=description).

This replaces Owlcat's function for reading `SharedStringAsset` from JSON with one that properly instantiates them.

Also includes a minor change to `Info.json`: `LoadAfter: [ "MewsiferConsole.Mod" ]`. This has no effect if the user does not have Mewsifer Console, but if they do it ensures that all logs for BugFixes are shown in the console.